### PR TITLE
CI: pin OpenMPI BLACS for ScaLAPACK to fix CPARDISO segfault

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,14 +25,14 @@ jobs:
         uses: actions/cache@v4
         with: 
           path: ${{github.workspace}}/petsc
-          key: ${{runner.os}}-petsc
+          key: ${{runner.os}}-petsc-openmpi-blacs
 
       - name: Build PETSc
         if: steps.cache-petsc.outputs.cache-hit != 'true'
         run: |
           git clone --depth 1 --branch v3.25.1 https://gitlab.com/petsc/petsc.git petsc
           cd petsc
-          ./configure --with-debugging=no --with-fortran-bindings=0 --with-blas-lapack-dir=/opt/intel/oneapi/mkl/latest/lib --with-mkl_cpardiso --with-mkl_pardiso --with-scalapack-dir=/opt/intel/oneapi/mkl/latest --download-triangle --download-ctetgen --download-parmetis --download-metis --download-mmg --download-ptscotch COPTFLAGS="-O3 -march=native" CXXOPTFLAGS="-O3 -march=native"
+          ./configure --with-debugging=no --with-fortran-bindings=0 --with-blas-lapack-dir=/opt/intel/oneapi/mkl/latest/lib --with-mkl_cpardiso --with-mkl_pardiso --with-scalapack-lib="-L/opt/intel/oneapi/mkl/latest/lib -lmkl_scalapack_lp64 -lmkl_blacs_openmpi_lp64" --download-triangle --download-ctetgen --download-parmetis --download-metis --download-mmg --download-ptscotch COPTFLAGS="-O3 -march=native" CXXOPTFLAGS="-O3 -march=native"
           make PETSC_DIR=${GITHUB_WORKSPACE}/petsc PETSC_ARCH=arch-linux-c-opt all
 
       - name: Build ParMGMC


### PR DESCRIPTION
PETSc's ScaLAPACK.py picks libmkl_blacs_intelmpi_lp64 from a static list (intelmpi first) when given --with-scalapack-dir, even under OpenMPI. It links fine but the comm-handle ABI mismatch crashes MKL CPARDISO at runtime (parallel coarse Cholesky in GAMGMC). Replace --with-scalapack-dir with an explicit --with-scalapack-lib that uses mkl_blacs_openmpi_lp64, matching the BLAS/LAPACK selection. Bump the PETSc cache key so the broken cached build is not reused.