### PR TITLE
Fix FFTW and BLAS linkage on macOS and add macOS CI job

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,53 @@
+name: macos
+on: [push]
+jobs:
+  run-tests:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew install open-mpi fftw pkg-config bison flex pipx
+          pipx install lit
+          pipx ensurepath
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix flex)/bin" >> $GITHUB_PATH
+
+      - name: Cache PETSc
+        id: cache-petsc
+        uses: actions/cache@v4
+        with:
+          path: ${{github.workspace}}/petsc
+          key: ${{runner.os}}-petsc-accelerate
+
+      - name: Build PETSc
+        if: steps.cache-petsc.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v3.25.1 https://gitlab.com/petsc/petsc.git petsc
+          cd petsc
+          # No Intel MKL on macOS: PETSc uses the Accelerate framework for BLAS/LAPACK.
+          ./configure --with-debugging=no --with-fortran-bindings=0 --with-fc=0 --with-cc=mpicc --with-cxx=mpicxx --download-triangle --download-ctetgen --download-parmetis --download-metis --download-mmg --download-ptscotch COPTFLAGS="-O3" CXXOPTFLAGS="-O3"
+          make PETSC_DIR=${GITHUB_WORKSPACE}/petsc PETSC_ARCH=arch-darwin-c-opt all
+
+      - name: Build ParMGMC
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/petsc/arch-darwin-c-opt -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
+          make
+
+      - name: Install ParMGMC
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          make install
+
+      - name: Configure tests
+        run: |
+          cd ${GITHUB_WORKSPACE}/examples
+          mkdir build && cd build
+          cmake .. -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/petsc/arch-darwin-c-opt;${GITHUB_WORKSPACE}/install"
+
+      - name: Run sequential tests
+        run: |
+          cd ${GITHUB_WORKSPACE}/examples/build
+          OMP_NUM_THREADS=1 make check-seq

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,24 @@ else()
   message(STATUS "Intel MKL not found — Box-Muller fallback used for random number generation")
 endif()
 
+# pc_chols.c calls BLAS/LAPACK; link the same one PETSc uses (read from
+# petscvariables) so it resolves at link time on macOS without an ABI mismatch.
+pkg_get_variable(PETSC_PREFIX PETSc prefix)
+set(PETSC_BLASLAPACK_LIB "")
+if(PETSC_PREFIX AND EXISTS "${PETSC_PREFIX}/lib/petsc/conf/petscvariables")
+  file(STRINGS "${PETSC_PREFIX}/lib/petsc/conf/petscvariables" _blas_line REGEX "^BLASLAPACK_LIB = ")
+  string(REGEX REPLACE "^BLASLAPACK_LIB = " "" _blas_line "${_blas_line}")
+  separate_arguments(PETSC_BLASLAPACK_LIB UNIX_COMMAND "${_blas_line}")
+endif()
+if(PETSC_BLASLAPACK_LIB)
+  message(STATUS "Using PETSc's BLAS/LAPACK: ${PETSC_BLASLAPACK_LIB}")
+  set(PARMGMC_BLAS_LINK ${PETSC_BLASLAPACK_LIB})
+else()
+  message(STATUS "PETSc BLAS/LAPACK not recorded; falling back to find_package(BLAS)")
+  find_package(BLAS REQUIRED)
+  set(PARMGMC_BLAS_LINK BLAS::BLAS)
+endif()
+
 # iact.c needs a double-precision FFTW.
 find_package(FFTW COMPONENTS DOUBLE_LIB REQUIRED)
 
@@ -65,7 +83,7 @@ target_sources(parmgmc
 target_include_directories(parmgmc SYSTEM PUBLIC ${PETSC_INCLUDE_DIRS} ${FFTW_INCLUDE_DIRS})
 target_compile_options(parmgmc PRIVATE -Wall -Wextra -Wpedantic -pedantic -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes)
 target_compile_options(parmgmc PUBLIC ${PETSC_CFLAGS})
-target_link_libraries(parmgmc PUBLIC PkgConfig::PETSC MPI::MPI_C FFTW::Double)
+target_link_libraries(parmgmc PUBLIC PkgConfig::PETSC MPI::MPI_C FFTW::Double ${PARMGMC_BLAS_LINK})
 
 add_executable(benchmark examples/benchmark/main.cc)
 target_include_directories(benchmark PRIVATE include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,8 @@ else()
   message(STATUS "Intel MKL not found — Box-Muller fallback used for random number generation")
 endif()
 
-find_package(FFTW)
-message(STATUS ${FFTW_INCLUDE_DIRS} ${FFTW_LIBRARIES})
-if (DEFINED FFTW_INCLUDE_DIRS AND NOT DEFINED FFTW_LIBRARIES)
-  message(STATUS "Found FFTW include dirs but no libs, assuming that Intel MKL FFTW is used")
-  if(NOT MKL_FOUND)
-    message(FATAL_ERROR "FFTW headers found without FFTW libs but MKL was not detected. Install Intel MKL or provide FFTW libraries.")
-  endif()
-  set(FFTW_DOUBLE_LIB "") # Linking MKL::MKL directly segfaults; PETSc's transitive MKL dep resolves symbols.
-endif()
+# iact.c needs a double-precision FFTW.
+find_package(FFTW COMPONENTS DOUBLE_LIB REQUIRED)
 
 add_library(parmgmc SHARED)
 
@@ -72,12 +65,12 @@ target_sources(parmgmc
 target_include_directories(parmgmc SYSTEM PUBLIC ${PETSC_INCLUDE_DIRS} ${FFTW_INCLUDE_DIRS})
 target_compile_options(parmgmc PRIVATE -Wall -Wextra -Wpedantic -pedantic -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes)
 target_compile_options(parmgmc PUBLIC ${PETSC_CFLAGS})
-target_link_libraries(parmgmc PUBLIC PkgConfig::PETSC MPI::MPI_C )
+target_link_libraries(parmgmc PUBLIC PkgConfig::PETSC MPI::MPI_C FFTW::Double)
 
 add_executable(benchmark examples/benchmark/main.cc)
 target_include_directories(benchmark PRIVATE include)
 target_compile_options(benchmark PRIVATE -Wall -Wextra -Wpedantic -pedantic)
-target_link_libraries(benchmark PRIVATE parmgmc m MPI::MPI_CXX MPI::MPI_C ${FFTW_DOUBLE_LIB})
+target_link_libraries(benchmark PRIVATE parmgmc m MPI::MPI_CXX MPI::MPI_C)
 
 # add_executable(test test.c)
 # target_include_directories(test PRIVATE include)


### PR DESCRIPTION
For some reason, on macOS BLAS symbols are not found even though PETSc
itself is always linked against BLAS. So we try to find PETSc's BLAS
link line and reuse that; if that fails, just find_package(BLAS) and
hope for the best.

Fixes #7  
Fixes #6 